### PR TITLE
Set up scripts to run the seed and create a local database for testing

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -41,6 +41,7 @@ lerna-debug.log*
 .env.test.local
 .env.production.local
 .env.local
+.env.test
 
 # temp directory
 .temp

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-fastify": "^11.0.15",
         "@prisma/client": "^6.6.0",
+        "dotenv": "^16.5.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -3115,6 +3116,18 @@
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/config/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "11.0.15",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.0.15.tgz",
@@ -6069,9 +6082,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -31,6 +31,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
+        "dotenv-cli": "^8.0.0",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -6091,6 +6092,32 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-8.0.0.tgz",
+      "integrity": "sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,10 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "seed": "ts-node prisma/runSeed.ts"
+    "seed": "ts-node prisma/runSeed.ts",
+    "setup-test-db": "psql -f ./prisma/setup-local-db.sql",
+    "push:test": "dotenv -e .env.test -- prisma db push",
+    "seed:test": "dotenv -e .env.test ts-node prisma/runSeed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -43,6 +46,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
+    "dotenv-cli": "^8.0.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node prisma/runSeed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -26,6 +27,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-fastify": "^11.0.15",
     "@prisma/client": "^6.6.0",
+    "dotenv": "^16.5.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/backend/prisma/prisma-client.ts
+++ b/backend/prisma/prisma-client.ts
@@ -1,0 +1,8 @@
+import { config } from 'dotenv';
+
+const path = process.env.NODE_ENV === 'test' ? '.env.test' : '.env';
+config({ path });
+
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/backend/prisma/runSeed.ts
+++ b/backend/prisma/runSeed.ts
@@ -1,0 +1,8 @@
+import { seedTestDatabase } from "./seed";
+
+seedTestDatabase().then(() => {
+    console.log('Database seeded');
+})
+.catch((err) => {
+    console.log(err);
+})

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,4 +1,7 @@
+import {config} from 'dotenv';
 import { PrismaClient, Prisma } from '@prisma/client'
+
+config({path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env'});
 
 const prisma = new PrismaClient()
 
@@ -6,20 +9,52 @@ export async function seedTestDatabase() {
     //deletes everything under user
     await prisma.user.deleteMany();
 
-    // Check if posts should be included in the query
+    // If any of you guys want to change this test data feel free.
 
-    const user = {
-        "username": 'kc325423',
-        "nickname": 'Random guy',
-        "description": "First random user test guy",
-        "password": "dfgusdhgls",
-        "avatar_url": "https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?t=st=1744362533~exp=1744366133~hmac=04e1b1307000082639a4fb0e03834e3ecda1683cf6c7e88bbd48f7e22ddf9072&w=740",
-        "email": "randomguy23423@gmail.com"
-    }
+    const users = [
+        {
+            username: "kc325423",
+            nickname: "Random guy",
+            description: "First random user test guy",
+            password: "dfgusdhgls",
+            avatar_url: "https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?t=st=1744362533~exp=1744366133~hmac=04e1b1307000082639a4fb0e03834e3ecda1683cf6c7e88bbd48f7e22ddf9072&w=740",
+            email: "randomguy23423@gmail.com"
+        },
+        {
+            username: "RafalCzajka",
+            nickname: "Raf",
+            description: "Second test user",
+            password: "oneOfThePasswordsOfAllTime",
+            avatar_url: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg",
+            email: "rafal@gmail.com"
+        },
+        {
+            username: "OscarFinn",
+            nickname: "Oscar",
+            description: "Third test user",
+            password: "oneOfThePasswordsOfAllTime",
+            avatar_url: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg",
+            email: "oscar@gmail.com"
+        },
+        {
+            username: "ValentinPenev",
+            nickname: "Valentin",
+            description: "Fourth test user",
+            password: "oneOfThePasswordsOfAllTime",
+            avatar_url: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg",
+            email: "valentin@gmail.com"
+        },
+        {
+            username: "HenryTso",
+            nickname: "Henry",
+            description: "Fifth test user",
+            password: "oneOfThePasswordsOfAllTime",
+            avatar_url: "https://upload.wikimedia.org/wikipedia/commons/a/ac/Default_pfp.jpg",
+            email: "henry@gmail.com"
+        },
+    ];
 
 
-    // Pass 'user' object into query
-    const createUser = await prisma.user.create({ data: user })
+    //Insert test data into users table
+    await prisma.user.createMany({ data: users});
 }
-
-seedTestDatabase()

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,9 +1,4 @@
-import {config} from 'dotenv';
-import { PrismaClient, Prisma } from '@prisma/client'
-
-config({path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env'});
-
-const prisma = new PrismaClient()
+import { prisma } from "./prisma-client";
 
 export async function seedTestDatabase() {
     //deletes everything under user

--- a/backend/prisma/setup-local-db.sql
+++ b/backend/prisma/setup-local-db.sql
@@ -1,0 +1,2 @@
+DROP DATABASE IF EXISTS social_cam_test;
+CREATE DATABASE social_cam_test;


### PR DESCRIPTION
This commit includes:
- The setup for the seeding with a runSeed.ts file and a script to execute it from npm.
- A SQL file to create a local db so that prisma can set up the table schema on it. scripts for this are also included in package.json and should be run in order from setup-test-db down to seed:test.
- A env file needs to be made with the details of your local db as a DATABASE_URL and DIRECT_URL. They should contain the same information, but if both are not provided the production env file overrides it.
- Another file included is prisma/prisma-client.ts - this file creates a new prisma client using the passed in env. Using a custom Prisma client like this means that we will want to import this instead of PrismaClient from now on.