### PR TITLE
Implemented api endpoints for albums table and 2/3 endpoints for the pictures table

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -82,13 +82,13 @@ model Album {
 }
 
 model Picture {
-  album_id    Int
+  album_id    Int?
   picture_id  Int    @id @default(autoincrement())
   storage_id String @db.VarChar(100)
   type_id     Int
 
   //Foreign keys
-  album Album       @relation(fields: [album_id], references: [album_id])
+  album Album?       @relation(fields: [album_id], references: [album_id])
   type  PictureType @relation(fields: [type_id], references: [type_id])
 }
 

--- a/backend/src/api/albums.controller.spec.ts
+++ b/backend/src/api/albums.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AlbumsController } from './albums.controller';
+
+describe('AlbumsController', () => {
+  let controller: AlbumsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AlbumsController],
+    }).compile();
+
+    controller = module.get<AlbumsController>(AlbumsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/api/albums.controller.ts
+++ b/backend/src/api/albums.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe, Post, Body } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Post, Body, Patch, Query } from '@nestjs/common';
 import { AlbumsService } from './albums.service';
 
 @Controller('/api/albums')
@@ -14,5 +14,14 @@ export class AlbumsController {
     createAlbum(
         @Body() albumData: {album_name: string}) {
             return this.appService.createAlbum(albumData);
+    }
+
+    @Patch(':album_id')
+    updateAlbumPictures(
+        @Param('album_id', ParseIntPipe) album_id: number,
+        @Query('action') action: 'add' | 'remove',
+        @Body() body: {pictures: {picture_id: number}[]}
+    ) {
+        return this.appService.modifyAlbumPictures(album_id, action, body.pictures);
     }
 }

--- a/backend/src/api/albums.controller.ts
+++ b/backend/src/api/albums.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { AlbumsService } from './albums.service';
+
+@Controller('/api/albums')
+export class AlbumsController {
+    constructor(private readonly appService: AlbumsService) {}
+
+    @Get(':event_id')
+    getAlbum(@Param('event_id', ParseIntPipe) event_id: number) {
+        return this.appService.getAlbumByEventId(event_id);
+    }
+}

--- a/backend/src/api/albums.controller.ts
+++ b/backend/src/api/albums.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Post, Body } from '@nestjs/common';
 import { AlbumsService } from './albums.service';
 
 @Controller('/api/albums')
@@ -8,5 +8,11 @@ export class AlbumsController {
     @Get(':event_id')
     getAlbum(@Param('event_id', ParseIntPipe) event_id: number) {
         return this.appService.getAlbumByEventId(event_id);
+    }
+
+    @Post()
+    createAlbum(
+        @Body() albumData: {album_name: string}) {
+            return this.appService.createAlbum(albumData);
     }
 }

--- a/backend/src/api/albums.service.spec.ts
+++ b/backend/src/api/albums.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AlbumsService } from './albums.service';
+
+describe('AlbumsService', () => {
+  let service: AlbumsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AlbumsService],
+    }).compile();
+
+    service = module.get<AlbumsService>(AlbumsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/api/albums.service.ts
+++ b/backend/src/api/albums.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+import { Album } from '@prisma/client';
+
+@Injectable()
+export class AlbumsService {
+
+    constructor(private prisma: PrismaService) {}
+
+    async getAlbumByEventId(eventId: number) {
+        const event = await this.prisma.event.findUnique({
+            where: { event_id: eventId},
+            select: {album_id: true}
+        });
+
+        const album = await this.prisma.album.findUnique({
+            where: {album_id: event?.album_id}
+        })
+
+        return album;
+    }
+}

--- a/backend/src/api/albums.service.ts
+++ b/backend/src/api/albums.service.ts
@@ -19,4 +19,8 @@ export class AlbumsService {
 
         return album;
     }
+
+    async createAlbum(albumData): Promise <Album | null> {
+        return this.prisma.album.create({data: albumData})
+    }
 }

--- a/backend/src/api/albums.service.ts
+++ b/backend/src/api/albums.service.ts
@@ -23,4 +23,25 @@ export class AlbumsService {
     async createAlbum(albumData): Promise <Album | null> {
         return this.prisma.album.create({data: albumData})
     }
+
+    async modifyAlbumPictures(albumId: number, action: 'add'|'remove', pictures: {picture_id: number} []) {
+        const pictureIds = pictures.map((picture) => picture.picture_id);
+
+        if (action === 'add') {
+            const updated = await this.prisma.picture.updateMany({
+                where: {picture_id: {in: pictureIds}},
+                data: {album_id: albumId}
+            })
+            return {message: 'Pictures added to album', count: updated.count};
+        }
+        if (action === 'remove') {
+            const updated = await this.prisma.picture.updateMany({
+                where: {picture_id: { in: pictureIds}, album_id: albumId,},
+                data: {album_id: null}
+            })
+            return {message: 'Pictures removed from album', count: updated.count};
+        }
+
+        throw new Error('Invalid action. Use ?action=add or ?action=remove');
+    }
 }

--- a/backend/src/api/pictures.controller.spec.ts
+++ b/backend/src/api/pictures.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PicturesController } from './pictures.controller';
+
+describe('PicturesController', () => {
+  let controller: PicturesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PicturesController],
+    }).compile();
+
+    controller = module.get<PicturesController>(PicturesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/api/pictures.controller.ts
+++ b/backend/src/api/pictures.controller.ts
@@ -9,4 +9,9 @@ export class PicturesController {
     getPicture(@Param('picture_id', ParseIntPipe) picture_id: number) {
         return this.appService.getPictureById(picture_id);
     }
+
+    @Get('album/:album_id')
+    getAlbumPictures(@Param('album_id', ParseIntPipe) album_id: number) {
+        return this.appService.getAllAlbumPictures(album_id);
+    }
 }

--- a/backend/src/api/pictures.controller.ts
+++ b/backend/src/api/pictures.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { PicturesService } from './pictures.service';
+
+@Controller('/api/pictures')
+export class PicturesController {
+    constructor(private readonly appService: PicturesService) {}
+
+    @Get(':picture_id')
+    getPicture(@Param('picture_id', ParseIntPipe) picture_id: number) {
+        return this.appService.getPictureById(picture_id);
+    }
+}

--- a/backend/src/api/pictures.service.spec.ts
+++ b/backend/src/api/pictures.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PicturesService } from './pictures.service';
+
+describe('PicturesService', () => {
+  let service: PicturesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PicturesService],
+    }).compile();
+
+    service = module.get<PicturesService>(PicturesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/api/pictures.service.ts
+++ b/backend/src/api/pictures.service.ts
@@ -9,4 +9,10 @@ export class PicturesService {
     async getPictureById(pictureId): Promise<Picture|null> {
         return this.prisma.picture.findUnique({where: {picture_id: pictureId}})
     }
+
+    async getAllAlbumPictures(albumId: number) {
+        return this.prisma.picture.findMany({
+            where: {album_id: albumId}
+        })
+    }
 }

--- a/backend/src/api/pictures.service.ts
+++ b/backend/src/api/pictures.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma.service';
+import { Picture, Prisma } from '@prisma/client';
+
+@Injectable()
+export class PicturesService {
+    constructor(private prisma: PrismaService) {}
+
+    async getPictureById(pictureId): Promise<Picture|null> {
+        return this.prisma.picture.findUnique({where: {picture_id: pictureId}})
+    }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,8 @@ import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
 import { UsersService } from './api/users.service';
 import { UsersController } from './api/users.controller';
+import { AlbumsService } from './api/albums.service';
+import { AlbumsController } from './api/albums.controller';
 import { PrismaService } from './prisma.service';
 
 @Module({
@@ -12,7 +14,7 @@ import { PrismaService } from './prisma.service';
       envFilePath: `.env.${process.env.NODE_ENV || 'dev'}`,
     }),
   ],
-  controllers: [AppController, UsersController],
-  providers: [AppService, UsersService, PrismaService],
+  controllers: [AppController, UsersController, AlbumsController],
+  providers: [AppService, UsersService, AlbumsService, PrismaService],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,8 @@ import { UsersService } from './api/users.service';
 import { UsersController } from './api/users.controller';
 import { AlbumsService } from './api/albums.service';
 import { AlbumsController } from './api/albums.controller';
+import { PicturesService } from './api/pictures.service';
+import { PicturesController } from './api/pictures.controller';
 import { PrismaService } from './prisma.service';
 
 @Module({
@@ -14,7 +16,7 @@ import { PrismaService } from './prisma.service';
       envFilePath: `.env.${process.env.NODE_ENV || 'dev'}`,
     }),
   ],
-  controllers: [AppController, UsersController, AlbumsController],
-  providers: [AppService, UsersService, AlbumsService, PrismaService],
+  controllers: [AppController, UsersController, AlbumsController, PicturesController],
+  providers: [AppService, UsersService, AlbumsService, PicturesService, PrismaService],
 })
 export class AppModule {}


### PR DESCRIPTION
This commit includes:
- A change to the table schema to be able to set album_id to null in the pictures table. - **This change has not been pushed to the production database at the time of this pull request.**
- The implementation of the api endpoint GET /api/albums/:event_id to get the album for a specific event.
- The implementation of the api endpoint POST /api/albums to create a new album.
- The implementation of the api endpoint PATCH /api/albums/:album_id?action=add/remove - to update the album_id column in the pictures table for passed in pictures.
Example request body for this endpoint:
```
{
	"pictures": [
		{"picture_id": 1}
	]
}
```
**NOTE: Due to the updated table schema not being pushed to the production database yet at this point, the remove action was not able to be tested yet.**
- The implementation of the api endpoint GET /api/pictures/:picture_id to get picture by picture_id.
- The implementation of the api endpoint GET /api/pictures/album/:album_id to get all pictures by album_id